### PR TITLE
Modifying log contents in pkg/apis/maps/v1alpha1/webhook.go

### DIFF
--- a/pkg/apis/maps/v1alpha1/webhook.go
+++ b/pkg/apis/maps/v1alpha1/webhook.go
@@ -74,7 +74,7 @@ func (m *ElasticMapsServer) validate() (admission.Warnings, error) {
 	}
 
 	if len(errors) > 0 {
-		validationLog.V(1).Info("failed validation", "errors", errors)
+		validationLog.V(1).Info("failed validation", "errors", errors, "ElasticMapsServer Name", m.Name, "ElasticMapsServer Namespace", m.Namespace)
 		return nil, apierrors.NewInvalid(groupKind, m.Name, errors)
 	}
 	return nil, nil


### PR DESCRIPTION
The log line should be modified to include the name and namespace of the ElasticMapsServer instance to provide more context about which resource failed validation. The errors are already included, which is appropriate.


Created by Patchwork.